### PR TITLE
Add CSV transformer console app and CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '9.0.x'
+    - name: Restore
+      run: dotnet restore honeywell-article-transformer.sln
+    - name: Build
+      run: dotnet build honeywell-article-transformer.sln --configuration Release --no-restore
+    - name: Publish
+      run: dotnet publish src/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer.csproj --configuration Release -p:Version=1.0.${{ github.run_number }} --runtime win-x64 --self-contained true -o publish
+    - uses: actions/upload-artifact@v4
+      with:
+        name: Honeywell.ArticleTransformer
+        path: publish

--- a/honeywell-article-transformer.sln
+++ b/honeywell-article-transformer.sln
@@ -1,0 +1,42 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Honeywell.ArticleTransformer", "Honeywell.ArticleTransformer", "{3F86D579-7A89-93A0-C363-D314B352215E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honeywell.ArticleTransformer", "src\Honeywell.ArticleTransformer\Honeywell.ArticleTransformer\Honeywell.ArticleTransformer.csproj", "{2BA84E80-015B-46C2-9C6D-434FBA4AA93D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2BA84E80-015B-46C2-9C6D-434FBA4AA93D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2BA84E80-015B-46C2-9C6D-434FBA4AA93D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2BA84E80-015B-46C2-9C6D-434FBA4AA93D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2BA84E80-015B-46C2-9C6D-434FBA4AA93D}.Debug|x64.Build.0 = Debug|Any CPU
+		{2BA84E80-015B-46C2-9C6D-434FBA4AA93D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2BA84E80-015B-46C2-9C6D-434FBA4AA93D}.Debug|x86.Build.0 = Debug|Any CPU
+		{2BA84E80-015B-46C2-9C6D-434FBA4AA93D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2BA84E80-015B-46C2-9C6D-434FBA4AA93D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2BA84E80-015B-46C2-9C6D-434FBA4AA93D}.Release|x64.ActiveCfg = Release|Any CPU
+		{2BA84E80-015B-46C2-9C6D-434FBA4AA93D}.Release|x64.Build.0 = Release|Any CPU
+		{2BA84E80-015B-46C2-9C6D-434FBA4AA93D}.Release|x86.ActiveCfg = Release|Any CPU
+		{2BA84E80-015B-46C2-9C6D-434FBA4AA93D}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{3F86D579-7A89-93A0-C363-D314B352215E} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{2BA84E80-015B-46C2-9C6D-434FBA4AA93D} = {3F86D579-7A89-93A0-C363-D314B352215E}
+	EndGlobalSection
+EndGlobal

--- a/src/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer.csproj
+++ b/src/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <Version>1.0.0</Version>
+  </PropertyGroup>
+</Project>

--- a/src/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer/Program.cs
+++ b/src/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer/Program.cs
@@ -1,0 +1,66 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Honeywell.ArticleTransformer
+{
+    public static class Program
+    {
+        public static void Main(string[] args)
+        {
+            if (args.Length == 0)
+            {
+                Console.WriteLine("Usage: Honeywell.ArticleTransformer <input.csv>");
+                return;
+            }
+
+            var inputPath = args[0];
+            if (!File.Exists(inputPath))
+            {
+                Console.WriteLine($"Input file '{inputPath}' not found.");
+                return;
+            }
+
+            var lines = File.ReadAllLines(inputPath);
+            var outputLines = lines.Select(ProcessLine).ToArray();
+            File.WriteAllText("output.csv", string.Join("\r\n", outputLines), Encoding.UTF8);
+            Console.WriteLine("Processed file saved to output.csv");
+        }
+
+        private static string ProcessLine(string line)
+        {
+            var cells = line.Split(';');
+            for (var i = 0; i < cells.Length; i++)
+            {
+                cells[i] = TransformCell(cells[i]);
+            }
+
+            return string.Join(';', cells);
+        }
+
+        private static string TransformCell(string cell)
+        {
+            if (string.IsNullOrEmpty(cell))
+                return cell;
+
+            var text = cell.Replace("_x000D_", string.Empty)
+                            .Replace("\r\n", " ")
+                            .Replace("\n", " ")
+                            .Replace("\r", " ");
+
+            text = Regex.Replace(text, " {2,}", " ");
+
+            text = Regex.Replace(text, "\\s+(Anschl\\u00fcsse:|Technische Daten:|Betriebsspannung:)", "\r\n$1");
+
+            text = Regex.Replace(text, "(?<!Technische\\s)Daten:", m => "\r\n" + m.Value);
+            text = Regex.Replace(text, "Daten:\\s*$", "Daten:\r\n");
+
+            text = Regex.Replace(text, ":\\s*", ":\r\n");
+            text = Regex.Replace(text, "\\s*-", "\r\n-" );
+
+            return text.Trim();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Honeywell Article Transformer console app
- transform CSV fields and output in Windows newline format
- add solution file and project
- configure GitHub Actions workflow to build and publish Windows executable

## Testing
- `dotnet restore honeywell-article-transformer.sln`
- `dotnet build honeywell-article-transformer.sln --configuration Release --no-restore`
