### PR TITLE
Update pipeline for framework dependent build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,8 @@ jobs:
     - name: Build
       run: dotnet build honeywell-article-transformer.sln --configuration Release --no-restore
     - name: Publish
-      run: dotnet publish src/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer.csproj --configuration Release -p:Version=1.0.${{ github.run_number }} --runtime win-x64 --self-contained true -o publish
+      # Create framework-dependent build (no .NET runtime included)
+      run: dotnet publish src/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer.csproj --configuration Release -p:Version=1.0.${{ github.run_number }} --no-self-contained -o publish
     - uses: actions/upload-artifact@v4
       with:
         name: Honeywell.ArticleTransformer


### PR DESCRIPTION
## Summary
- update publish command to omit .NET runtime

## Testing
- `dotnet build honeywell-article-transformer.sln -c Release`
