### PR TITLE
Fix GitHub tag action permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: windows-latest


### PR DESCRIPTION
## Summary
- add explicit `permissions` block so tagging works

## Testing
- `dotnet build honeywell-article-transformer.sln --configuration Release --no-restore`