### PR TITLE
Add WPF GUI and refactor logic into library

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,7 @@ Bei CSV wird `output.csv` erzeugt, bei XLSX `output.xlsx`. Alle Zeilenumbrüche 
 2. Mehrfache Leerzeichen auf ein Leerzeichen reduzieren.
 3. Vor den Begriffen "Anschlüsse:", "Technische Daten:", "Daten:" und "Betriebsspannung:" einen Zeilenumbruch einfügen. Steht "Daten:" alleine, auch danach einen Zeilenumbruch. "Technische Daten" darf nicht getrennt werden. Nach jedem Doppelpunkt einen Zeilenumbruch einfügen. Beginnt danach eine Aufzählung, jede Zeile mit `-` beginnen und zuvor einen Zeilenumbruch einfügen.
 4. Technische Daten logisch und übersichtlich strukturieren. Keine Formatierungen einsetzen, leere Felder bleiben leer und vorhandene Schreibweise wird nicht korrigiert.
+
+## WPF-Anwendung
+
+Neben dem Konsolenprogramm gibt es ein WPF-Projekt. Darüber kann eine CSV- oder XLSX-Datei ausgewählt und per Button die Umwandlung gestartet werden. Die Ausgabedatei wird im selben Ordner gespeichert.

--- a/honeywell-article-transformer.sln
+++ b/honeywell-article-transformer.sln
@@ -9,6 +9,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Honeywell.ArticleTransforme
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honeywell.ArticleTransformer", "src\Honeywell.ArticleTransformer\Honeywell.ArticleTransformer\Honeywell.ArticleTransformer.csproj", "{2BA84E80-015B-46C2-9C6D-434FBA4AA93D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honeywell.ArticleTransformer.Core", "src\Honeywell.ArticleTransformer\Honeywell.ArticleTransformer.Core\Honeywell.ArticleTransformer.Core.csproj", "{C66E47BE-D204-41BA-A086-8C80C46F27DB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honeywell.ArticleTransformer.Gui", "src\Honeywell.ArticleTransformer\Honeywell.ArticleTransformer.Gui\Honeywell.ArticleTransformer.Gui.csproj", "{BADCFBC1-F4A7-4C53-B3AA-D26E1AF54BB2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,13 +34,39 @@ Global
 		{2BA84E80-015B-46C2-9C6D-434FBA4AA93D}.Release|x64.ActiveCfg = Release|Any CPU
 		{2BA84E80-015B-46C2-9C6D-434FBA4AA93D}.Release|x64.Build.0 = Release|Any CPU
 		{2BA84E80-015B-46C2-9C6D-434FBA4AA93D}.Release|x86.ActiveCfg = Release|Any CPU
-		{2BA84E80-015B-46C2-9C6D-434FBA4AA93D}.Release|x86.Build.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
+                {2BA84E80-015B-46C2-9C6D-434FBA4AA93D}.Release|x86.Build.0 = Release|Any CPU
+                {C66E47BE-D204-41BA-A086-8C80C46F27DB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {C66E47BE-D204-41BA-A086-8C80C46F27DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {C66E47BE-D204-41BA-A086-8C80C46F27DB}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {C66E47BE-D204-41BA-A086-8C80C46F27DB}.Debug|x64.Build.0 = Debug|Any CPU
+                {C66E47BE-D204-41BA-A086-8C80C46F27DB}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {C66E47BE-D204-41BA-A086-8C80C46F27DB}.Debug|x86.Build.0 = Debug|Any CPU
+                {C66E47BE-D204-41BA-A086-8C80C46F27DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {C66E47BE-D204-41BA-A086-8C80C46F27DB}.Release|Any CPU.Build.0 = Release|Any CPU
+                {C66E47BE-D204-41BA-A086-8C80C46F27DB}.Release|x64.ActiveCfg = Release|Any CPU
+                {C66E47BE-D204-41BA-A086-8C80C46F27DB}.Release|x64.Build.0 = Release|Any CPU
+                {C66E47BE-D204-41BA-A086-8C80C46F27DB}.Release|x86.ActiveCfg = Release|Any CPU
+                {C66E47BE-D204-41BA-A086-8C80C46F27DB}.Release|x86.Build.0 = Release|Any CPU
+                {BADCFBC1-F4A7-4C53-B3AA-D26E1AF54BB2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {BADCFBC1-F4A7-4C53-B3AA-D26E1AF54BB2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {BADCFBC1-F4A7-4C53-B3AA-D26E1AF54BB2}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {BADCFBC1-F4A7-4C53-B3AA-D26E1AF54BB2}.Debug|x64.Build.0 = Debug|Any CPU
+                {BADCFBC1-F4A7-4C53-B3AA-D26E1AF54BB2}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {BADCFBC1-F4A7-4C53-B3AA-D26E1AF54BB2}.Debug|x86.Build.0 = Debug|Any CPU
+                {BADCFBC1-F4A7-4C53-B3AA-D26E1AF54BB2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {BADCFBC1-F4A7-4C53-B3AA-D26E1AF54BB2}.Release|Any CPU.Build.0 = Release|Any CPU
+                {BADCFBC1-F4A7-4C53-B3AA-D26E1AF54BB2}.Release|x64.ActiveCfg = Release|Any CPU
+                {BADCFBC1-F4A7-4C53-B3AA-D26E1AF54BB2}.Release|x64.Build.0 = Release|Any CPU
+                {BADCFBC1-F4A7-4C53-B3AA-D26E1AF54BB2}.Release|x86.ActiveCfg = Release|Any CPU
+                {BADCFBC1-F4A7-4C53-B3AA-D26E1AF54BB2}.Release|x86.Build.0 = Release|Any CPU
+        EndGlobalSection
+        GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-		{3F86D579-7A89-93A0-C363-D314B352215E} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
-		{2BA84E80-015B-46C2-9C6D-434FBA4AA93D} = {3F86D579-7A89-93A0-C363-D314B352215E}
-	EndGlobalSection
+        GlobalSection(NestedProjects) = preSolution
+                {3F86D579-7A89-93A0-C363-D314B352215E} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+                {2BA84E80-015B-46C2-9C6D-434FBA4AA93D} = {3F86D579-7A89-93A0-C363-D314B352215E}
+                {C66E47BE-D204-41BA-A086-8C80C46F27DB} = {3F86D579-7A89-93A0-C363-D314B352215E}
+                {BADCFBC1-F4A7-4C53-B3AA-D26E1AF54BB2} = {3F86D579-7A89-93A0-C363-D314B352215E}
+        EndGlobalSection
 EndGlobal

--- a/src/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer.Core/Honeywell.ArticleTransformer.Core.csproj
+++ b/src/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer.Core/Honeywell.ArticleTransformer.Core.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer.Core/Transformer.cs
+++ b/src/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer.Core/Transformer.cs
@@ -1,0 +1,184 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Security;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+namespace Honeywell.ArticleTransformer.Core
+{
+    public static class Transformer
+    {
+        public static void ProcessFile(string inputPath, string outputPath)
+        {
+            if (!File.Exists(inputPath))
+                throw new FileNotFoundException($"Input file '{inputPath}' not found.");
+
+            var lines = Path.GetExtension(inputPath).Equals(".xlsx", StringComparison.OrdinalIgnoreCase)
+                ? ReadXlsx(inputPath)
+                : File.ReadAllLines(inputPath);
+
+            var outputLines = lines.Select(ProcessLine).ToArray();
+
+            if (Path.GetExtension(outputPath).Equals(".xlsx", StringComparison.OrdinalIgnoreCase))
+            {
+                WriteXlsx(outputPath, outputLines);
+            }
+            else
+            {
+                File.WriteAllText(outputPath, string.Join("\r\n", outputLines), Encoding.UTF8);
+            }
+        }
+
+        private static string ProcessLine(string line)
+        {
+            var cells = line.Split(';');
+            for (var i = 0; i < cells.Length; i++)
+            {
+                cells[i] = TransformCell(cells[i]);
+            }
+
+            return string.Join(';', cells);
+        }
+
+        private static string TransformCell(string cell)
+        {
+            if (string.IsNullOrEmpty(cell))
+                return cell;
+
+            var text = cell.Replace("_x000D_", string.Empty)
+                            .Replace("\r\n", " ")
+                            .Replace("\n", " ")
+                            .Replace("\r", " ");
+
+            text = Regex.Replace(text, " {2,}", " ");
+
+            text = Regex.Replace(text, "\\s+(Anschl\\u00fcsse:|Technische Daten:|Betriebsspannung:)", "\r\n$1");
+
+            text = Regex.Replace(text, "(?<!Technische\\s)Daten:", m => "\r\n" + m.Value);
+            text = Regex.Replace(text, "Daten:\\s*$", "Daten:\r\n");
+
+            text = Regex.Replace(text, ":\\s*", ":\r\n");
+            text = Regex.Replace(text, "\\s*-", "\r\n-" );
+
+            return text.Trim();
+        }
+
+        private static string[] ReadXlsx(string path)
+        {
+            using var archive = ZipFile.OpenRead(path);
+            var sheetEntry = archive.GetEntry("xl/worksheets/sheet1.xml");
+            if (sheetEntry == null)
+                return Array.Empty<string>();
+
+            var strings = Array.Empty<string>();
+            var stringsEntry = archive.GetEntry("xl/sharedStrings.xml");
+            if (stringsEntry != null)
+            {
+                using var reader = new StreamReader(stringsEntry.Open());
+                var doc = XDocument.Load(reader);
+                var ns = doc.Root!.Name.Namespace;
+                strings = doc.Descendants(ns + "t").Select(t => t.Value).ToArray();
+            }
+
+            using var sheetReader = new StreamReader(sheetEntry.Open());
+            var sheetDoc = XDocument.Load(sheetReader);
+            var n = sheetDoc.Root!.Name.Namespace;
+            var rows = sheetDoc.Descendants(n + "row");
+            return rows.Select(r => string.Join(';', r.Elements(n + "c").Select(c =>
+            {
+                var t = c.Attribute("t")?.Value;
+                if (t == "s")
+                {
+                    var v = c.Element(n + "v")?.Value;
+                    if (int.TryParse(v, out var idx) && idx >= 0 && idx < strings.Length)
+                        return strings[idx];
+                    return string.Empty;
+                }
+                if (t == "inlineStr")
+                {
+                    return c.Element(n + "is")?.Element(n + "t")?.Value ?? string.Empty;
+                }
+                return c.Element(n + "v")?.Value ?? string.Empty;
+            }))).ToArray();
+        }
+
+        private static void WriteXlsx(string path, string[] lines)
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+
+            using var archive = ZipFile.Open(path, ZipArchiveMode.Create);
+            AddEntry(archive, "[Content_Types].xml",
+                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
+                "<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\">" +
+                "<Default Extension=\"rels\" ContentType=\"application/vnd.openxmlformats-package.relationships+xml\"/>" +
+                "<Default Extension=\"xml\" ContentType=\"application/xml\"/>" +
+                "<Override PartName=\"/xl/workbook.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\"/>" +
+                "<Override PartName=\"/xl/worksheets/sheet1.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml\"/>" +
+                "</Types>");
+
+            AddEntry(archive, "_rels/.rels",
+                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
+                "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">" +
+                "<Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\" Target=\"xl/workbook.xml\"/>" +
+                "</Relationships>");
+
+            AddEntry(archive, "xl/_rels/workbook.xml.rels",
+                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
+                "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">" +
+                "<Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\" Target=\"worksheets/sheet1.xml\"/>" +
+                "</Relationships>");
+
+            AddEntry(archive, "xl/workbook.xml",
+                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
+                "<workbook xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">" +
+                "<sheets><sheet name=\"Sheet1\" sheetId=\"1\" r:id=\"rId1\"/></sheets>" +
+                "</workbook>");
+
+            var sb = new StringBuilder();
+            sb.Append("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>");
+            sb.Append("<worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\"><sheetData>");
+            for (var r = 0; r < lines.Length; r++)
+            {
+                var cells = lines[r].Split(';');
+                sb.Append($"<row r=\"{r + 1}\">");
+                for (var c = 0; c < cells.Length; c++)
+                {
+                    var cellRef = ColumnName(c) + (r + 1);
+                    sb.Append($"<c r=\"{cellRef}\" t=\"inlineStr\"><is><t>{EscapeXml(cells[c])}</t></is></c>");
+                }
+                sb.Append("</row>");
+            }
+            sb.Append("</sheetData></worksheet>");
+            AddEntry(archive, "xl/worksheets/sheet1.xml", sb.ToString());
+        }
+
+        private static void AddEntry(ZipArchive archive, string path, string content)
+        {
+            var entry = archive.CreateEntry(path);
+            using var writer = new StreamWriter(entry.Open(), new UTF8Encoding(false));
+            writer.Write(content);
+        }
+
+        private static string ColumnName(int index)
+        {
+            var dividend = index + 1;
+            var columnName = string.Empty;
+            while (dividend > 0)
+            {
+                var modulo = (dividend - 1) % 26;
+                columnName = Convert.ToChar(65 + modulo) + columnName;
+                dividend = (dividend - modulo) / 26;
+            }
+            return columnName;
+        }
+
+        private static string EscapeXml(string value)
+        {
+            return SecurityElement.Escape(value) ?? string.Empty;
+        }
+    }
+}

--- a/src/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer.Gui/App.xaml
+++ b/src/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer.Gui/App.xaml
@@ -1,0 +1,7 @@
+<Application x:Class="Honeywell.ArticleTransformer.Gui.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+    </Application.Resources>
+</Application>

--- a/src/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer.Gui/App.xaml.cs
+++ b/src/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer.Gui/App.xaml.cs
@@ -1,0 +1,8 @@
+using System.Windows;
+
+namespace Honeywell.ArticleTransformer.Gui
+{
+    public partial class App : Application
+    {
+    }
+}

--- a/src/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer.Gui/Honeywell.ArticleTransformer.Gui.csproj
+++ b/src/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer.Gui/Honeywell.ArticleTransformer.Gui.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net9.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <UseWPF>true</UseWPF>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Honeywell.ArticleTransformer.Core\Honeywell.ArticleTransformer.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer.Gui/MainWindow.xaml
+++ b/src/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer.Gui/MainWindow.xaml
@@ -1,0 +1,10 @@
+<Window x:Class="Honeywell.ArticleTransformer.Gui.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Article Transformer" Height="150" Width="400">
+    <StackPanel Margin="10">
+        <TextBox x:Name="FilePathBox" Margin="0,0,0,10" IsReadOnly="True"/>
+        <Button Content="Select File" Click="OnSelectFile" Margin="0,0,0,10"/>
+        <Button Content="Start" Click="OnStart" />
+    </StackPanel>
+</Window>

--- a/src/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer.Gui/MainWindow.xaml.cs
+++ b/src/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer.Gui/MainWindow.xaml.cs
@@ -1,0 +1,43 @@
+using Microsoft.Win32;
+using System.IO;
+using System.Windows;
+using Honeywell.ArticleTransformer.Core;
+
+namespace Honeywell.ArticleTransformer.Gui
+{
+    public partial class MainWindow : Window
+    {
+        public MainWindow()
+        {
+            InitializeComponent();
+        }
+
+        private void OnSelectFile(object sender, RoutedEventArgs e)
+        {
+            var dialog = new OpenFileDialog
+            {
+                Filter = "CSV or XLSX|*.csv;*.xlsx"
+            };
+            if (dialog.ShowDialog() == true)
+            {
+                FilePathBox.Text = dialog.FileName;
+            }
+        }
+
+        private void OnStart(object sender, RoutedEventArgs e)
+        {
+            var path = FilePathBox.Text;
+            if (!File.Exists(path))
+            {
+                MessageBox.Show("Please select a valid file.");
+                return;
+            }
+
+            var outputExtension = Path.GetExtension(path).Equals(".xlsx", System.StringComparison.OrdinalIgnoreCase)
+                ? ".xlsx" : ".csv";
+            var outputPath = Path.Combine(Path.GetDirectoryName(path) ?? string.Empty, $"output{outputExtension}");
+            Transformer.ProcessFile(path, outputPath);
+            MessageBox.Show($"Processed file saved to {outputPath}");
+        }
+    }
+}

--- a/src/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer.Gui/Program.cs
+++ b/src/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer.Gui/Program.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Windows;
+
+namespace Honeywell.ArticleTransformer.Gui
+{
+    public class Program
+    {
+        [STAThread]
+        public static void Main(string[] args)
+        {
+            var app = new App();
+            app.InitializeComponent();
+            app.Run();
+        }
+    }
+}

--- a/src/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer.csproj
+++ b/src/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer.csproj
@@ -6,4 +6,7 @@
     <Nullable>enable</Nullable>
     <Version>1.0.0</Version>
   </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Honeywell.ArticleTransformer.Core\Honeywell.ArticleTransformer.Core.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer/Program.cs
+++ b/src/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer/Program.cs
@@ -1,11 +1,6 @@
 using System;
 using System.IO;
-using System.IO.Compression;
-using System.Linq;
-using System.Security;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Xml.Linq;
+using Honeywell.ArticleTransformer.Core;
 
 namespace Honeywell.ArticleTransformer
 {
@@ -26,171 +21,12 @@ namespace Honeywell.ArticleTransformer
                 return;
             }
 
-            string[] lines = Path.GetExtension(inputPath).Equals(".xlsx", StringComparison.OrdinalIgnoreCase)
-                ? ReadXlsx(inputPath)
-                : File.ReadAllLines(inputPath);
+            var outputExtension = Path.GetExtension(inputPath).Equals(".xlsx", StringComparison.OrdinalIgnoreCase)
+                ? ".xlsx" : ".csv";
+            var outputPath = Path.Combine(Path.GetDirectoryName(inputPath) ?? string.Empty, $"output{outputExtension}");
 
-            var outputLines = lines.Select(ProcessLine).ToArray();
-
-            if (Path.GetExtension(inputPath).Equals(".xlsx", StringComparison.OrdinalIgnoreCase))
-            {
-                WriteXlsx("output.xlsx", outputLines);
-                Console.WriteLine("Processed file saved to output.xlsx");
-            }
-            else
-            {
-                File.WriteAllText("output.csv", string.Join("\r\n", outputLines), Encoding.UTF8);
-                Console.WriteLine("Processed file saved to output.csv");
-            }
-        }
-
-        private static string ProcessLine(string line)
-        {
-            var cells = line.Split(';');
-            for (var i = 0; i < cells.Length; i++)
-            {
-                cells[i] = TransformCell(cells[i]);
-            }
-
-            return string.Join(';', cells);
-        }
-
-        private static string TransformCell(string cell)
-        {
-            if (string.IsNullOrEmpty(cell))
-                return cell;
-
-            var text = cell.Replace("_x000D_", string.Empty)
-                            .Replace("\r\n", " ")
-                            .Replace("\n", " ")
-                            .Replace("\r", " ");
-
-            text = Regex.Replace(text, " {2,}", " ");
-
-            text = Regex.Replace(text, "\\s+(Anschl\\u00fcsse:|Technische Daten:|Betriebsspannung:)", "\r\n$1");
-
-            text = Regex.Replace(text, "(?<!Technische\\s)Daten:", m => "\r\n" + m.Value);
-            text = Regex.Replace(text, "Daten:\\s*$", "Daten:\r\n");
-
-            text = Regex.Replace(text, ":\\s*", ":\r\n");
-            text = Regex.Replace(text, "\\s*-", "\r\n-" );
-
-            return text.Trim();
-        }
-
-        private static string[] ReadXlsx(string path)
-        {
-            using var archive = ZipFile.OpenRead(path);
-            var sheetEntry = archive.GetEntry("xl/worksheets/sheet1.xml");
-            if (sheetEntry == null)
-                return Array.Empty<string>();
-
-            var strings = new string[0];
-            var stringsEntry = archive.GetEntry("xl/sharedStrings.xml");
-            if (stringsEntry != null)
-            {
-                using var reader = new StreamReader(stringsEntry.Open());
-                var doc = XDocument.Load(reader);
-                var ns = doc.Root!.Name.Namespace;
-                strings = doc.Descendants(ns + "t").Select(t => t.Value).ToArray();
-            }
-
-            using var sheetReader = new StreamReader(sheetEntry.Open());
-            var sheetDoc = XDocument.Load(sheetReader);
-            var n = sheetDoc.Root!.Name.Namespace;
-            var rows = sheetDoc.Descendants(n + "row");
-            return rows.Select(r => string.Join(';', r.Elements(n + "c").Select(c =>
-            {
-                var t = c.Attribute("t")?.Value;
-                if (t == "s")
-                {
-                    var v = c.Element(n + "v")?.Value;
-                    if (int.TryParse(v, out var idx) && idx >= 0 && idx < strings.Length)
-                        return strings[idx];
-                    return string.Empty;
-                }
-                if (t == "inlineStr")
-                {
-                    return c.Element(n + "is")?.Element(n + "t")?.Value ?? string.Empty;
-                }
-                return c.Element(n + "v")?.Value ?? string.Empty;
-            }))).ToArray();
-        }
-
-        private static void WriteXlsx(string path, string[] lines)
-        {
-            if (File.Exists(path))
-                File.Delete(path);
-
-            using var archive = ZipFile.Open(path, ZipArchiveMode.Create);
-            AddEntry(archive, "[Content_Types].xml",
-                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
-                "<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\">" +
-                "<Default Extension=\"rels\" ContentType=\"application/vnd.openxmlformats-package.relationships+xml\"/>" +
-                "<Default Extension=\"xml\" ContentType=\"application/xml\"/>" +
-                "<Override PartName=\"/xl/workbook.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\"/>" +
-                "<Override PartName=\"/xl/worksheets/sheet1.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml\"/>" +
-                "</Types>");
-
-            AddEntry(archive, "_rels/.rels",
-                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
-                "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">" +
-                "<Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\" Target=\"xl/workbook.xml\"/>" +
-                "</Relationships>");
-
-            AddEntry(archive, "xl/_rels/workbook.xml.rels",
-                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
-                "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">" +
-                "<Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\" Target=\"worksheets/sheet1.xml\"/>" +
-                "</Relationships>");
-
-            AddEntry(archive, "xl/workbook.xml",
-                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
-                "<workbook xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">" +
-                "<sheets><sheet name=\"Sheet1\" sheetId=\"1\" r:id=\"rId1\"/></sheets>" +
-                "</workbook>");
-
-            var sb = new StringBuilder();
-            sb.Append("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>");
-            sb.Append("<worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\"><sheetData>");
-            for (var r = 0; r < lines.Length; r++)
-            {
-                var cells = lines[r].Split(';');
-                sb.Append($"<row r=\"{r + 1}\">");
-                for (var c = 0; c < cells.Length; c++)
-                {
-                    var cellRef = ColumnName(c) + (r + 1);
-                    sb.Append($"<c r=\"{cellRef}\" t=\"inlineStr\"><is><t>{EscapeXml(cells[c])}</t></is></c>");
-                }
-                sb.Append("</row>");
-            }
-            sb.Append("</sheetData></worksheet>");
-            AddEntry(archive, "xl/worksheets/sheet1.xml", sb.ToString());
-        }
-
-        private static void AddEntry(ZipArchive archive, string path, string content)
-        {
-            var entry = archive.CreateEntry(path);
-            using var writer = new StreamWriter(entry.Open(), new UTF8Encoding(false));
-            writer.Write(content);
-        }
-
-        private static string ColumnName(int index)
-        {
-            var dividend = index + 1;
-            var columnName = string.Empty;
-            while (dividend > 0)
-            {
-                var modulo = (dividend - 1) % 26;
-                columnName = Convert.ToChar(65 + modulo) + columnName;
-                dividend = (dividend - modulo) / 26;
-            }
-            return columnName;
-        }
-
-        private static string EscapeXml(string value)
-        {
-            return SecurityElement.Escape(value) ?? string.Empty;
+            Transformer.ProcessFile(inputPath, outputPath);
+            Console.WriteLine($"Processed file saved to {Path.GetFileName(outputPath)}");
         }
     }
 }


### PR DESCRIPTION
## Summary
- extract all transformation logic into new `Honeywell.ArticleTransformer.Core` library
- simplify console program to call the library
- introduce a WPF project with buttons to pick a file and start the conversion
- enable Windows targeting so the GUI can build on Windows
- mention the GUI in the README

## Testing
- `dotnet build src/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer.csproj`
- `dotnet build src/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer.Core/Honeywell.ArticleTransformer.Core.csproj`
- `dotnet build src/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer.Gui/Honeywell.ArticleTransformer.Gui.csproj` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json)*

------
https://chatgpt.com/codex/tasks/task_b_6842bc65478483209c831778714ce1f0