### PR TITLE
Fix encoding for CSV input

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Honeywell.ArticleTransformer.exe eingabe.xlsx
 ```
 
 Bei CSV wird `output.csv` erzeugt, bei XLSX `output.xlsx`. Alle Zeilenumbrüche im Ergebnis nutzen das Windows-Format (UTF-8).
+CSV-Dateien werden zunächst als UTF-8 gelesen. Enthält die Datei ungültige UTF-8-Bytes, erfolgt automatisch ein zweiter Versuch mit Windows-1252 (Latin-1). Das Ergebnis wird immer in UTF-8 gespeichert.
 
 ## Transformationsschritte
 

--- a/src/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer.Core/Transformer.cs
+++ b/src/Honeywell.ArticleTransformer/Honeywell.ArticleTransformer.Core/Transformer.cs
@@ -18,7 +18,7 @@ namespace Honeywell.ArticleTransformer.Core
 
             var lines = Path.GetExtension(inputPath).Equals(".xlsx", StringComparison.OrdinalIgnoreCase)
                 ? ReadXlsx(inputPath)
-                : File.ReadAllLines(inputPath);
+                : ReadCsv(inputPath);
 
             var outputLines = lines.Select(ProcessLine).ToArray();
 
@@ -64,6 +64,19 @@ namespace Honeywell.ArticleTransformer.Core
             text = Regex.Replace(text, "\\s*-", "\r\n-" );
 
             return text.Trim();
+        }
+
+        private static string[] ReadCsv(string path)
+        {
+            try
+            {
+                var utf8 = new UTF8Encoding(false, true);
+                return File.ReadAllLines(path, utf8);
+            }
+            catch (DecoderFallbackException)
+            {
+                return File.ReadAllLines(path, Encoding.GetEncoding(1252));
+            }
         }
 
         private static string[] ReadXlsx(string path)


### PR DESCRIPTION
## Summary
- detect invalid UTF-8 in CSV files
- fall back to Windows-1252 when needed
- document encoding behaviour in README

## Testing
- `dotnet test`
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_b_6842c11482c08320a7400dfe71aeaf92